### PR TITLE
Allow clients to provide a retryCondition function

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This module provides fault-tolerance on top of [@segment/jsonrpc2](github.com/se
 
 - [x] Retries via [`p-retry`](https://github.com/sindresorhus/p-retry)
 - [x] Timeout via [`p-timeout`](https://github.com/sindresorhus/p-timeout)
+- [x] Optional retry logic
 - [ ] Circuit Breaking not yet implemented
 
 
@@ -32,6 +33,16 @@ function Client (addr, opts) {
   // We should only allow retries for idempotent requests
   const idempotentDefaults = Object.assign({
     retryOptions: { retries: 3 },
+
+    // Custom retry function
+    // This allows the clients to decide what sorts of errors
+    // are worth retrying
+    shouldRetry: function(originalError) {
+      if (originalError.code === "SYSTEM_ERROR") {
+        return true
+      }
+      return false
+    }
     timeout: 500,
     totalTimeout: 2000
   }, opts.idempotentDefaults)

--- a/index.js
+++ b/index.js
@@ -6,21 +6,22 @@ const pTimeout = require('p-timeout')
 const RPCTimeoutError = require('./lib/rpc_timeout_error')
 
 const noRetryDefault = { retries: 0 }
+const defaultRetryPredicate = () => true
 
 module.exports = Client
 module.exports.RPCTimeoutError = RPCTimeoutError
 
-function Client (addr, opts) {
-  if (!(this instanceof Client)) return new Client(addr, opts)
+function Client (addr, libraryOptions) {
+  if (!(this instanceof Client)) return new Client(addr, libraryOptions)
 
-  opts = opts || {}
+  libraryOptions = libraryOptions || {}
 
-  const rpcOptions = {
-    timeout: opts.timeout,
-    logger: opts.logger
+  const originalRpcClientOptions = {
+    timeout: libraryOptions.timeout,
+    logger: libraryOptions.logger
   }
 
-  const rpc = new RPC(addr, rpcOptions)
+  const rpc = new RPC(addr, originalRpcClientOptions)
   const call = rpc.call.bind(rpc)
 
   rpc.call = function (method, params, options) {
@@ -28,8 +29,13 @@ function Client (addr, opts) {
 
     // Allow overriding options at the individual request level.
     // Retries are opt-in and turned off by default.
-    const retryOptions = Object.assign({}, noRetryDefault, opts.retryOptions, options.retryOptions)
-    const totalTimeout = options.totalTimeout || opts.totalTimeout || 1000
+    const retryOptions = Object.assign({}, noRetryDefault, libraryOptions.retryOptions, options.retryOptions)
+    const totalTimeout = options.totalTimeout || libraryOptions.totalTimeout || 1000
+
+    // Decides whether or not we should retry a given request.
+    // The client can decide if they want to retry 404s, or just other types
+    // of errors such as ECONNREFUSED, ESOCKETTIMEDOUT and other common network errors
+    const retryPredicate = libraryOptions.shouldRetry || options.shouldRetry || defaultRetryPredicate
 
     return new Promise((resolve, reject) => {
       let hasTimedOut = false
@@ -45,7 +51,17 @@ function Client (addr, opts) {
         return call(method, params, {
           timeout: options.timeout,
           async: options.async
-        })
+        }).catch(shouldRetry)
+      }
+
+      function shouldRetry (err) {
+        if (retryPredicate(err)) {
+          // Keep retrying
+          return Promise.reject(err)
+        } else {
+          // Abort retry flow
+          throw new pRetry.AbortError(err)
+        }
       }
 
       function fallback () {

--- a/test.js
+++ b/test.js
@@ -64,6 +64,39 @@ test.serial('retry off by default', async t => {
   t.is(error.message, 'failed')
 })
 
+test.serial('custom retry logic', async t => {
+  let i = 0
+  nock(HOST)
+    .filteringRequestBody(() => '*')
+    .post('/rpc', '*')
+    .times(2)
+    .reply(500, () => {
+      i++
+      if (i === 2) {
+        return { error: 'application_error' }
+      }
+      return { error: 'network_error' }
+    })
+
+  const options = {
+    retryOptions: {
+      retries: 2
+    },
+    shouldRetry: function (err) {
+      if (err.message === 'application_error') {
+        return false
+      }
+      return true
+    },
+    totalTimeout: 100000
+  }
+
+  const error = await t.throws(rpc.call('Items.GetAll', null, options))
+
+  t.is(i, 2)
+  t.is(error.message, 'application_error')
+})
+
 test.serial('timeout', async t => {
   const timeout = 10
   const retries = 100


### PR DESCRIPTION
This will allow clients to choose which sorts of errors they want the
fault tolerant library to retry.

We'll then be able to decide whether or not we want application errors
to be retried, but still retry on system errors.